### PR TITLE
Updated used action steps

### DIFF
--- a/.github/workflows/comment_pr_package.yml
+++ b/.github/workflows/comment_pr_package.yml
@@ -67,41 +67,39 @@ jobs:
       - name: List extracted Files
         run: ls -lah artifacts
 
-      - name: Read the pr number artifact
+      - name: Read the PR number artifact
         id: pr_number_reader
         run: |
           PR_NUMBER=$(cat artifacts/pr_number.txt)
           echo "PR number: $PR_NUMBER"
-          echo "::set-output name=pr_number::$PR_NUMBER"
+          echo "$PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
 
       - name: Read the artifact URL
         id: artifact_url_reader
         run: |
           ARTIFACT_URL=$(cat artifacts/artifact_url.txt)
           echo "Artifact URL: $ARTIFACT_URL"
-          echo "::set-output name=artifact_url::$ARTIFACT_URL"
+          echo "$ARTIFACT_URL=$ARTIFACT_URL" >> "$GITHUB_ENV"
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
+      - name: Find PR Comment ID
         id: find-comment
-        with:
-          issue-number: ${{ steps.pr_number_reader.outputs.pr_number }}
-          comment-author: 'github-actions[bot]'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ env.PR_NUMBER }}
+          COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments \
+          --jq '.[] | select(.user.login=="github-actions[bot]") | .id')
+          echo "comment_id=$COMMENT_ID" >> "$GITHUB_ENV"
+
       - name: Update Comment
         env:
-          ARTIFACT_URL: "${{ steps.artifact_url_reader.outputs.artifact_url }}"
-          HEAD_SHA: "${{ github.event.head_sha }}"
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ github.token }}
-          issue-number:  ${{ steps.pr_number_reader.outputs.pr_number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body: |-
-            ![badge]
-            
-            Plugin zip package for the changes in this PR has been successfully built!.
-            
-            Download the plugin zip file from here ${{ env.ARTIFACT_URL }}
-            
-            [badge]: https://img.shields.io/badge/package_build-success-green
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ env.COMMENT_ID }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+            --method PATCH \
+            --input - <<EOF
+          {
+            "body": "![badge]\nPlugin zip package for the changes in this PR has been successfully built!.\nDownload the plugin zip file from here ${{ env.ARTIFACT_URL }}\n[badge]: https://img.shields.io/badge/package_build-success-green"
+          }
+          EOF


### PR DESCRIPTION
Replace the deprecated `set-output` with the environment variables and now using Github API to find and update the PR comments.